### PR TITLE
Add configuration for timeout

### DIFF
--- a/docs/ephemeral-resources/azure_cli_credential.md
+++ b/docs/ephemeral-resources/azure_cli_credential.md
@@ -44,6 +44,7 @@ ephemeral "azidentity_azure_cli_credential" "this" {
 - `enable_cae` (Boolean) EnableCAE indicates whether to enable Continuous Access Evaluation (CAE) for the requested token. When true, azidentity credentials request CAE tokens for resource APIs supporting CAE. Clients are responsible for handling CAE challenges. If a client that doesn't handle CAE challenges receives a CAE token, it may end up in a loop retrying an API call with a token that has been revoked due to CAE. The default is false.
 - `subscription_id` (String) SubscriptionID is the ID (or name) of a subscription. Set this to acquire tokens for an account other than the Azure CLI's current account. The default is empty.
 - `tenant_id` (String) TenantID sets the default tenant for authentication via the Azure CLI and workload identity. The default is empty, use 'organizations' or 'common' if you can't provide one but required to use one.
+- `timeout` (String) Timeout sets the maximum time allowed for the request to complete, the string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5h' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. The default is 30 seconds ('30s').
 
 ### Read-Only
 

--- a/docs/ephemeral-resources/client_assertion_credential.md
+++ b/docs/ephemeral-resources/client_assertion_credential.md
@@ -195,6 +195,7 @@ steps:
 - `continue_on_error` (Boolean) ContinueOnError indicates whether to continue on error when acquiring a token. The default is false.
 - `disable_instance_discovery` (Boolean) DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential requests Microsoft Entra instance metadata from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making the application responsible for ensuring the configured authority is valid and trustworthy. The default is false.
 - `enable_cae` (Boolean) EnableCAE indicates whether to enable Continuous Access Evaluation (CAE) for the requested token. When true, azidentity credentials request CAE tokens for resource APIs supporting CAE. Clients are responsible for handling CAE challenges. If a client that doesn't handle CAE challenges receives a CAE token, it may end up in a loop retrying an API call with a token that has been revoked due to CAE. The default is false.
+- `timeout` (String) Timeout sets the maximum time allowed for the request to complete, the string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5h' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. The default is 30 seconds ('30s').
 
 ### Read-Only
 

--- a/docs/ephemeral-resources/client_secret_credential.md
+++ b/docs/ephemeral-resources/client_secret_credential.md
@@ -50,6 +50,7 @@ ephemeral "azidentity_client_secret_credential" "this" {
 - `continue_on_error` (Boolean) ContinueOnError indicates whether to continue on error when acquiring a token. The default is false.
 - `disable_instance_discovery` (Boolean) DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential requests Microsoft Entra instance metadata from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making the application responsible for ensuring the configured authority is valid and trustworthy. The default is false.
 - `enable_cae` (Boolean) EnableCAE indicates whether to enable Continuous Access Evaluation (CAE) for the requested token. When true, azidentity credentials request CAE tokens for resource APIs supporting CAE. Clients are responsible for handling CAE challenges. If a client that doesn't handle CAE challenges receives a CAE token, it may end up in a loop retrying an API call with a token that has been revoked due to CAE. The default is false.
+- `timeout` (String) Timeout sets the maximum time allowed for the request to complete, the string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5h' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. The default is 30 seconds ('30s').
 
 ### Read-Only
 

--- a/docs/ephemeral-resources/default_credential.md
+++ b/docs/ephemeral-resources/default_credential.md
@@ -45,6 +45,7 @@ ephemeral "azidentity_default_credential" "this" {
 - `disable_instance_discovery` (Boolean) DisableInstanceDiscovery should be set true only by applications authenticating in disconnected clouds, or private clouds such as Azure Stack. It determines whether the credential requests Microsoft Entra instance metadata from https://login.microsoft.com before authenticating. Setting this to true will skip this request, making the application responsible for ensuring the configured authority is valid and trustworthy. The default is false.
 - `enable_cae` (Boolean) EnableCAE indicates whether to enable Continuous Access Evaluation (CAE) for the requested token. When true, azidentity credentials request CAE tokens for resource APIs supporting CAE. Clients are responsible for handling CAE challenges. If a client that doesn't handle CAE challenges receives a CAE token, it may end up in a loop retrying an API call with a token that has been revoked due to CAE. The default is false.
 - `tenant_id` (String) TenantID sets the default tenant for authentication via the Azure CLI and workload identity. The default is empty, use 'organizations' or 'common' if you can't provide one but required to use one.
+- `timeout` (String) Timeout sets the maximum time allowed for the request to complete, the string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5h' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. The default is 30 seconds ('30s').
 
 ### Read-Only
 

--- a/docs/ephemeral-resources/http_request.md
+++ b/docs/ephemeral-resources/http_request.md
@@ -62,6 +62,7 @@ check "ip" {
 - `continue_on_error` (Boolean) ContinueOnError indicates whether to continue on error when the http request fails. The default is false.
 - `request_body` (String, Sensitive) The body of the HTTP request. Defaults to an empty body.
 - `request_headers` (Map of String, Sensitive) The headers to include in the HTTP request.
+- `timeout` (String) Timeout sets the maximum time allowed for the request to complete, the string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5h' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. The default is 30 seconds ('30s').
 
 ### Read-Only
 

--- a/internal/provider/credential_test.go
+++ b/internal/provider/credential_test.go
@@ -57,6 +57,32 @@ func (c *testCredentialFailure) GetToken(ctx context.Context, options policy.Tok
 
 var _ azcore.TokenCredential = (*testCredentialFailure)(nil)
 
+func testNewGetCredentialTimeoutFn(t *testing.T, timeout time.Duration) getCredentialFn {
+	t.Helper()
+
+	return func(credType credentialType, cfg credentialConfig) (azcore.TokenCredential, error) {
+		return &testCredentialTimeout{
+			t:       t,
+			timeout: timeout,
+		}, nil
+	}
+}
+
+type testCredentialTimeout struct {
+	t       *testing.T
+	timeout time.Duration
+}
+
+func (c *testCredentialTimeout) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c.t.Helper()
+
+	time.Sleep(c.timeout)
+
+	return azcore.AccessToken{}, ctx.Err()
+}
+
+var _ azcore.TokenCredential = (*testCredentialTimeout)(nil)
+
 func testNewTestCredentialFailureFn(t *testing.T) getCredentialFn {
 	t.Helper()
 

--- a/internal/provider/credential_test.go
+++ b/internal/provider/credential_test.go
@@ -57,7 +57,7 @@ func (c *testCredentialFailure) GetToken(ctx context.Context, options policy.Tok
 
 var _ azcore.TokenCredential = (*testCredentialFailure)(nil)
 
-func testNewGetCredentialTimeoutFn(t *testing.T, timeout time.Duration) getCredentialFn {
+func testNewGetCredentialTimeoutFn(t *testing.T, timeout time.Duration) getCredentialFn { // nolint: unparam
 	t.Helper()
 
 	return func(credType credentialType, cfg credentialConfig) (azcore.TokenCredential, error) {

--- a/internal/provider/ephemeral_azure_cli_credential_test.go
+++ b/internal/provider/ephemeral_azure_cli_credential_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -233,6 +234,33 @@ func TestEphemeralAzureCLICredentialFailGetToken(t *testing.T) {
 						}),
 					),
 				},
+			},
+		},
+	})
+}
+
+func TestEphemeralAzureCLICredentialGetCredentialTimeout(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactoriesWithEcho(t, testNewGetCredentialTimeoutFn(t, 50*time.Millisecond)),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+ephemeral "azidentity_azure_cli_credential" "this" {
+	scopes  = ["ze-scope-1"]
+	timeout = "10ms"
+}
+
+provider "echo" {
+  data = ephemeral.azidentity_azure_cli_credential.this
+}
+
+resource "echo" "this" {}
+`,
+				ExpectError: regexp.MustCompile(`context deadline exceeded`),
 			},
 		},
 	})

--- a/internal/provider/ephemeral_azure_cli_credential_test.go
+++ b/internal/provider/ephemeral_azure_cli_credential_test.go
@@ -79,6 +79,11 @@ func TestEphemeralAzureCLICredentialEmpty(t *testing.T) {
 						tfjsonpath.New("data").AtMapKey("continue_on_error"),
 						knownvalue.Null(),
 					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.Null(),
+					),
 				},
 			},
 		},
@@ -156,6 +161,11 @@ func TestEphemeralAzureCLICredential(t *testing.T) {
 						"echo.this",
 						tfjsonpath.New("data").AtMapKey("continue_on_error"),
 						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.StringExact("1s"),
 					),
 				},
 			},
@@ -252,6 +262,7 @@ ephemeral "azidentity_azure_cli_credential" "this" {
 	enable_cae                   = true
 	scopes                       = ["ze-scope-1", "ze-scope-2"]
 	continue_on_error            = true
+	timeout 					 = "1s"
 }
 
 provider "echo" {

--- a/internal/provider/ephemeral_client_assertion_credential_test.go
+++ b/internal/provider/ephemeral_client_assertion_credential_test.go
@@ -84,6 +84,11 @@ func TestEphemeralClientAssertionCredentialEmpty(t *testing.T) {
 						tfjsonpath.New("data").AtMapKey("continue_on_error"),
 						knownvalue.Null(),
 					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.Null(),
+					),
 				},
 			},
 		},
@@ -166,6 +171,11 @@ func TestEphemeralClientAssertionCredential(t *testing.T) {
 						"echo.this",
 						tfjsonpath.New("data").AtMapKey("continue_on_error"),
 						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.StringExact("1s"),
 					),
 				},
 			},
@@ -281,6 +291,7 @@ ephemeral "azidentity_client_assertion_credential" "this" {
 	enable_cae                   = true
 	scopes                       = ["ze-scope-1", "ze-scope-2"]
 	continue_on_error            = true
+	timeout                      = "1s"
 }
 
 provider "echo" {

--- a/internal/provider/ephemeral_client_assertion_credential_test.go
+++ b/internal/provider/ephemeral_client_assertion_credential_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -258,6 +259,36 @@ func TestEphemeralClientAssertionCredentialFailGetToken(t *testing.T) {
 						}),
 					),
 				},
+			},
+		},
+	})
+}
+
+func TestEphemeralClientAssertionCredentialGetTokenTimeout(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactoriesWithEcho(t, testNewGetCredentialTimeoutFn(t, 50*time.Millisecond)),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+ephemeral "azidentity_client_assertion_credential" "this" {
+	tenant_id = "ze-tenant"
+	client_id = "ze-client"
+	assertion = "ze-assertion"
+    scopes    = ["ze-scope-1"]
+	timeout   = "10ms"
+}
+
+provider "echo" {
+  data = ephemeral.azidentity_client_assertion_credential.this
+}
+
+resource "echo" "this" {}
+`,
+				ExpectError: regexp.MustCompile(`context deadline exceeded`),
 			},
 		},
 	})

--- a/internal/provider/ephemeral_client_secret_credential.go
+++ b/internal/provider/ephemeral_client_secret_credential.go
@@ -36,13 +36,14 @@ type ephemeralClientSecretCredentialModel struct {
 	EnableCAE                  types.Bool   `tfsdk:"enable_cae"`
 	Scopes                     types.Set    `tfsdk:"scopes"`
 	ContinueOnError            types.Bool   `tfsdk:"continue_on_error"`
+	Timeout                    types.String `tfsdk:"timeout"`
 	AccessToken                types.String `tfsdk:"access_token"`
 	ExpiresOn                  types.String `tfsdk:"expires_on"`
 	Success                    types.Bool   `tfsdk:"success"`
 	Error                      types.String `tfsdk:"error"`
 }
 
-func (r *ephemeralClientSecretCredentialModel) newCredentialConfig() credentialConfig {
+func (r *ephemeralClientSecretCredentialModel) newCredentialConfig(ctx context.Context) credentialConfig {
 	return credentialConfig{
 		CloudConfig:                getCloudConfig(r.Cloud.ValueString()),
 		TenantID:                   r.TenantID.ValueString(),
@@ -54,6 +55,7 @@ func (r *ephemeralClientSecretCredentialModel) newCredentialConfig() credentialC
 		EnableCAE:                  r.EnableCAE.ValueBool(),
 		Scopes:                     typesSetToStringSlice(r.Scopes),
 		ContinueOnError:            r.ContinueOnError.ValueBool(),
+		Timeout:                    parseTimeout(ctx, r.Timeout),
 	}
 }
 
@@ -115,6 +117,10 @@ func (r *ephemeralClientSecretCredential) Schema(ctx context.Context, _ ephemera
 				MarkdownDescription: "ContinueOnError indicates whether to continue on error when acquiring a token. The default is false.",
 				Optional:            true,
 			},
+			"timeout": schema.StringAttribute{
+				MarkdownDescription: "Timeout sets the maximum time allowed for the request to complete, the string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as '300ms', '1.5h' or '2h45m'. Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'. The default is 30 seconds ('30s').",
+				Optional:            true,
+			},
 			"access_token": schema.StringAttribute{
 				MarkdownDescription: "The issued access token.",
 				Computed:            true,
@@ -161,7 +167,7 @@ func (r *ephemeralClientSecretCredential) Open(ctx context.Context, req ephemera
 		return
 	}
 
-	cfg := data.newCredentialConfig()
+	cfg := data.newCredentialConfig(ctx)
 	token, errSummary, err := getToken(ctx, clientSecretCredential, r.getCredFn, cfg)
 	if err != nil && cfg.ContinueOnError {
 		data.Error = types.StringValue(err.Error())

--- a/internal/provider/ephemeral_client_secret_credential_test.go
+++ b/internal/provider/ephemeral_client_secret_credential_test.go
@@ -84,6 +84,11 @@ func TestEphemeralClientSecretCredentialEmpty(t *testing.T) {
 						tfjsonpath.New("data").AtMapKey("continue_on_error"),
 						knownvalue.Null(),
 					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.Null(),
+					),
 				},
 			},
 		},
@@ -166,6 +171,11 @@ func TestEphemeralClientSecretCredential(t *testing.T) {
 						"echo.this",
 						tfjsonpath.New("data").AtMapKey("continue_on_error"),
 						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.StringExact("1s"),
 					),
 				},
 			},
@@ -281,6 +291,7 @@ ephemeral "azidentity_client_secret_credential" "this" {
 	enable_cae                   = true
 	scopes                       = ["ze-scope-1", "ze-scope-2"]
 	continue_on_error            = true
+	timeout                      = "1s"
 }
 
 provider "echo" {

--- a/internal/provider/ephemeral_default_credential_test.go
+++ b/internal/provider/ephemeral_default_credential_test.go
@@ -84,6 +84,11 @@ func TestEphemeralDefaultCredentialEmpty(t *testing.T) {
 						tfjsonpath.New("data").AtMapKey("continue_on_error"),
 						knownvalue.Null(),
 					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.Null(),
+					),
 				},
 			},
 		},
@@ -166,6 +171,11 @@ func TestEphemeralDefaultCredential(t *testing.T) {
 						"echo.this",
 						tfjsonpath.New("data").AtMapKey("continue_on_error"),
 						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.StringExact("1s"),
 					),
 				},
 			},
@@ -263,6 +273,7 @@ ephemeral "azidentity_default_credential" "this" {
 	enable_cae                   = true
 	scopes                       = ["ze-scope-1", "ze-scope-2"]
 	continue_on_error            = true
+	timeout                      = "1s"
 }
 
 provider "echo" {

--- a/internal/provider/ephemeral_http_request_test.go
+++ b/internal/provider/ephemeral_http_request_test.go
@@ -79,6 +79,11 @@ resource "echo" "this" {}
 						tfjsonpath.New("data").AtMapKey("success"),
 						knownvalue.Bool(true),
 					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.Null(),
+					),
 				},
 			},
 		},
@@ -128,6 +133,7 @@ ephemeral "azidentity_http_request" "this" {
 	request_headers = {
 		"Content-Type" = "application/json"
 	}
+	timeout         = "1s"
 }
 
 provider "echo" {
@@ -176,6 +182,11 @@ resource "echo" "this" {}
 						"echo.this",
 						tfjsonpath.New("data").AtMapKey("success"),
 						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.StringExact("1s"),
 					),
 				},
 			},

--- a/internal/provider/ephemeral_http_request_test.go
+++ b/internal/provider/ephemeral_http_request_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -286,6 +287,114 @@ resource "echo" "this" {}
 						"echo.this",
 						tfjsonpath.New("data").AtMapKey("error"),
 						knownvalue.StringRegexp(regexp.MustCompile(`connection refused`)),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestEphemeralHttpRequestGetTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+	}))
+	serverURL := server.URL
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactoriesWithEcho(t, testNewTestCredentialFn(t)),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+ephemeral "azidentity_http_request" "this" {
+	request_url    = "%s"
+	request_method = "GET"
+	timeout 	   = "10ms"
+}
+
+provider "echo" {
+  data = ephemeral.azidentity_http_request.this
+}
+
+resource "echo" "this" {}
+`, serverURL),
+				ExpectError: regexp.MustCompile(`context deadline exceeded`),
+			},
+		},
+	})
+}
+
+func TestEphemeralHttpRequestGetTimeoutContinueOnError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+	}))
+	serverURL := server.URL
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactoriesWithEcho(t, testNewTestCredentialFn(t)),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+ephemeral "azidentity_http_request" "this" {
+	request_url       = "%s"
+	request_method    = "GET"
+	continue_on_error = true
+	timeout 	      = "10ms"
+}
+
+provider "echo" {
+  data = ephemeral.azidentity_http_request.this
+}
+
+resource "echo" "this" {}
+`, serverURL),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("request_url"),
+						knownvalue.StringExact(server.URL),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("request_method"),
+						knownvalue.StringExact("GET"),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("timeout"),
+						knownvalue.StringExact("10ms"),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("response_body"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("response_status_code"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("response_headers"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("success"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"echo.this",
+						tfjsonpath.New("data").AtMapKey("error"),
+						knownvalue.StringRegexp(regexp.MustCompile(`context deadline exceeded`)),
 					),
 				},
 			},


### PR DESCRIPTION
This PR introduces configurable timeout to the ephemeral resources `azidentity_azure_cli_credential`, `azidentity_client_assertion_credential`, `azidentity_client_secret_credential`, `azidentity_default_credential` and `azidentity_http_request`. Defaults to '30s'.